### PR TITLE
Enable SPA routing in Quarkus Quinoa

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -28,3 +28,4 @@ quarkus.dev-ui.cors.enabled=false
 quarkus.quinoa.package-manager-install=true
 quarkus.quinoa.package-manager-install.node-version=22.2.0
 quarkus.quinoa.build-dir=dist
+quarkus.quinoa.enable-spa-routing=true


### PR DESCRIPTION
Updated the application.properties file to turn on Single Page App (SPA) routing for the Quarkus Quinoa application. This change will simplify the routing process in our single page application setup.